### PR TITLE
Grow 1362 collect page hub entry points

### DIFF
--- a/src/Apps/Collect/CollectApp.tsx
+++ b/src/Apps/Collect/CollectApp.tsx
@@ -71,9 +71,9 @@ export class CollectApp extends Component<CollectAppProps> {
             </Serif>
 
             <CollectionsHubsNav
-              marketingHubCollections={
-                this.props.viewer.marketingHubCollections
-              }
+            // marketingHubCollections={
+            //   this.props.viewer.marketingHubCollections
+            // }
             />
 
             <Sans size="3" weight="medium">
@@ -119,9 +119,9 @@ export const CollectAppFragmentContainer = createFragmentContainer(CollectApp, {
         ...SeoProductsForArtworks_artworks
       }
 
-      marketingHubCollections {
-        ...CollectionsHubsNav_marketingHubCollections
-      }
+      # marketingHubCollections {
+      #   ...CollectionsHubsNav_marketingHubCollections
+      # }
 
       ...CollectFilterContainer_viewer
         @arguments(

--- a/src/Apps/Collect/CollectApp.tsx
+++ b/src/Apps/Collect/CollectApp.tsx
@@ -1,5 +1,6 @@
-import { Box, Flex, Sans, Separator, Serif } from "@artsy/palette"
+import { Separator, Serif } from "@artsy/palette"
 import { CollectApp_viewer } from "__generated__/CollectApp_viewer.graphql"
+import { CollectionsHubsNav_marketingCollections } from "__generated__/CollectionsHubsNav_marketingCollections.graphql"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { track } from "Artsy/Analytics"
 import * as Schema from "Artsy/Analytics/Schema"
@@ -16,6 +17,7 @@ import { SeoProductsForArtworks } from "./Components/Seo/SeoProductsForArtworks"
 
 export interface CollectAppProps {
   viewer?: CollectApp_viewer
+  marketingCollections?: CollectionsHubsNav_marketingCollections
   params?: {
     medium: string
   }
@@ -64,10 +66,9 @@ export class CollectApp extends Component<CollectAppProps> {
             Collect art and design online
           </Serif>
           <Separator mt={2} mb={4} />
+
           <CollectionsHubsNav
-          // marketingHubCollections={
-          //   this.props.viewer.marketingHubCollections
-          // }
+            marketingCollections={this.props.marketingCollections}
           />
           <Separator mb={2} mt={4} />
 
@@ -107,10 +108,6 @@ export const CollectAppFragmentContainer = createFragmentContainer(CollectApp, {
       filter_artworks(aggregations: $aggregations, size: 0) {
         ...SeoProductsForArtworks_artworks
       }
-
-      # marketingHubCollections {
-      #   ...CollectionsHubsNav_marketingHubCollections
-      # }
 
       ...CollectFilterContainer_viewer
         @arguments(

--- a/src/Apps/Collect/CollectApp.tsx
+++ b/src/Apps/Collect/CollectApp.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Sans, Serif } from "@artsy/palette"
+import { Box, Flex, Sans, Separator, Serif } from "@artsy/palette"
 import { CollectApp_viewer } from "__generated__/CollectApp_viewer.graphql"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { track } from "Artsy/Analytics"
@@ -60,29 +60,18 @@ export class CollectApp extends Component<CollectAppProps> {
           />
           <SeoProductsForArtworks artworks={filter_artworks} />
 
-          <Flex
-            mt={3}
-            mb={4}
-            justifyContent="space-between"
-            alignItems="flex-end"
-          >
-            <Serif size="8">
-              <h1>Collect art and design online</h1>
-            </Serif>
+          <Serif size="8" mt={3} element="h1">
+            Collect art and design online
+          </Serif>
+          <Separator mt={2} mb={4} />
+          <CollectionsHubsNav
+          // marketingHubCollections={
+          //   this.props.viewer.marketingHubCollections
+          // }
+          />
+          <Separator mb={2} mt={4} />
 
-            <CollectionsHubsNav
-            // marketingHubCollections={
-            //   this.props.viewer.marketingHubCollections
-            // }
-            />
-
-            <Sans size="3" weight="medium">
-              <a href="/collections">View collections</a>
-            </Sans>
-          </Flex>
-          <Box>
-            <ArtworkGrid viewer={this.props.viewer} />
-          </Box>
+          <ArtworkGrid viewer={this.props.viewer} />
         </FrameWithRecentlyViewed>
       </AppContainer>
     )

--- a/src/Apps/Collect/Components/Filters/FilterContainer.tsx
+++ b/src/Apps/Collect/Components/Filters/FilterContainer.tsx
@@ -122,7 +122,6 @@ export class FilterContainer extends React.Component<
                     <Separator mb={2} mt={-1} />
                   </Box>
                   <Box width="75%">
-                    <Separator mb={2} mt={-1} />
                     <span id="jump--collectArtworkGrid" />
                     <SortFilter
                       filters={filters}

--- a/src/Apps/Collect/Components/Filters/SortFilter.tsx
+++ b/src/Apps/Collect/Components/Filters/SortFilter.tsx
@@ -19,7 +19,7 @@ export const SortFilter: React.FC<{
 }> = ({ filters, onShow, sortType }) => {
   return (
     <Flex justifyContent={["space-between", "flex-end"]} alignItems="center">
-      <Box mt={-0.5}>
+      <Box>
         <SelectSmall
           options={getSortOptions(sortType)}
           selected={filters.state.sort}

--- a/src/Apps/Collect/routes.tsx
+++ b/src/Apps/Collect/routes.tsx
@@ -64,6 +64,9 @@ export const routes: RouteConfig[] = [
               page: $page
             )
         }
+        marketingCollections(size: 6) {
+          ...CollectionsHubsNav_marketingCollections
+        }
       }
     `,
     render: ({ props, Component }) => {

--- a/src/Components/CollectionsHubsNav.tsx
+++ b/src/Components/CollectionsHubsNav.tsx
@@ -1,7 +1,8 @@
 import { CollectionsHubsNav_marketingHubCollections } from "__generated__/CollectionsHubsNav_marketingHubCollections.graphql"
 import React, { SFC } from "react"
-import { createFragmentContainer, graphql } from "react-relay"
+// import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
+import { marketingHubCollections } from "./_fixtures_/collectionsHubs"
 import { ImageLink } from "./ImageLink"
 
 interface CollectionsHubsNavProps {
@@ -27,17 +28,22 @@ const NavWrapper = styled.nav`
   justify-content: space-between;
 `
 
-export const CollectionsHubsNavFragmentContainer = createFragmentContainer(
-  CollectionsHubsNav,
-  {
-    marketingHubCollections: graphql`
-      fragment CollectionsHubsNav_marketingHubCollections on MarketingCollection
-        @relay(plural: true) {
-        id
-        slug
-        title
-        thumbnail
-      }
-    `,
-  }
-)
+export const CollectionsHubsNavFragmentContainer = () => {
+  return (
+    <CollectionsHubsNav marketingHubCollections={marketingHubCollections} />
+  )
+}
+// export const CollectionsHubsNavFragmentContainer = createFragmentContainer(
+//   CollectionsHubsNav,
+//   {
+//     marketingHubCollections: graphql`
+//       fragment CollectionsHubsNav_marketingHubCollections on MarketingCollection
+//         @relay(plural: true) {
+//         id
+//         slug
+//         title
+//         thumbnail
+//       }
+//     `,
+//   }
+// )

--- a/src/Components/CollectionsHubsNav.tsx
+++ b/src/Components/CollectionsHubsNav.tsx
@@ -1,24 +1,24 @@
-import { CollectionsHubsNav_marketingHubCollections } from "__generated__/CollectionsHubsNav_marketingHubCollections.graphql"
+import { CollectionsHubsNav_marketingCollections } from "__generated__/CollectionsHubsNav_marketingCollections.graphql"
 import React, { SFC } from "react"
-// import { createFragmentContainer, graphql } from "react-relay"
+import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
-import { marketingHubCollections } from "./_fixtures_/collectionsHubs"
 import { ImageLink } from "./ImageLink"
 
 interface CollectionsHubsNavProps {
-  marketingHubCollections: CollectionsHubsNav_marketingHubCollections
+  marketingCollections: CollectionsHubsNav_marketingCollections
 }
 
 export const CollectionsHubsNav: SFC<CollectionsHubsNavProps> = props => {
   return (
     <NavWrapper>
-      {props.marketingHubCollections.map(hub => (
+      {props.marketingCollections.map(hub => (
         <ImageLink
           href={`/collection/${hub.slug}`}
-          imageUrl={hub.thumbnail}
+          imageUrl={hub.thumbnail || "http://placekitten.com/136/85"}
           width={[132, 132, 120, 136]}
           height={[83, 83, 74, 85]}
           mr={2}
+          key={hub.id}
         >
           {hub.title}
         </ImageLink>
@@ -34,22 +34,17 @@ const NavWrapper = styled.nav`
   justify-content: space-between;
 `
 
-export const CollectionsHubsNavFragmentContainer = () => {
-  return (
-    <CollectionsHubsNav marketingHubCollections={marketingHubCollections} />
-  )
-}
-// export const CollectionsHubsNavFragmentContainer = createFragmentContainer(
-//   CollectionsHubsNav,
-//   {
-//     marketingHubCollections: graphql`
-//       fragment CollectionsHubsNav_marketingHubCollections on MarketingCollection
-//         @relay(plural: true) {
-//         id
-//         slug
-//         title
-//         thumbnail
-//       }
-//     `,
-//   }
-// )
+export const CollectionsHubsNavFragmentContainer = createFragmentContainer(
+  CollectionsHubsNav,
+  {
+    marketingCollections: graphql`
+      fragment CollectionsHubsNav_marketingCollections on MarketingCollection
+        @relay(plural: true) {
+        id
+        slug
+        title
+        thumbnail
+      }
+    `,
+  }
+)

--- a/src/Components/CollectionsHubsNav.tsx
+++ b/src/Components/CollectionsHubsNav.tsx
@@ -16,8 +16,9 @@ export const CollectionsHubsNav: SFC<CollectionsHubsNavProps> = props => {
         <ImageLink
           href={`/collection/${hub.slug}`}
           imageUrl={hub.thumbnail}
-          width={[132, 132, 120, 168]}
-          height={[83, 83, 74, 105]}
+          width={[132, 132, 120, 136]}
+          height={[83, 83, 74, 85]}
+          mr={2}
         >
           {hub.title}
         </ImageLink>

--- a/src/Components/CollectionsHubsNav.tsx
+++ b/src/Components/CollectionsHubsNav.tsx
@@ -13,7 +13,12 @@ export const CollectionsHubsNav: SFC<CollectionsHubsNavProps> = props => {
   return (
     <NavWrapper>
       {props.marketingHubCollections.map(hub => (
-        <ImageLink href={`/collection/${hub.slug}`} imageUrl={hub.thumbnail}>
+        <ImageLink
+          href={`/collection/${hub.slug}`}
+          imageUrl={hub.thumbnail}
+          width={[132, 132, 120, 168]}
+          height={[83, 83, 74, 105]}
+        >
           {hub.title}
         </ImageLink>
       ))}

--- a/src/Components/__stories__/CollectionsHubsNav.story.tsx
+++ b/src/Components/__stories__/CollectionsHubsNav.story.tsx
@@ -1,5 +1,4 @@
 import { Theme } from "@artsy/palette"
-import { CollectionsHubsNav_marketingHubCollections } from "__generated__/CollectionsHubsNav_marketingHubCollections.graphql"
 import { MockRelayRenderer } from "DevTools"
 import React from "react"
 import { graphql } from "react-relay"

--- a/src/Components/__stories__/CollectionsHubsNav.story.tsx
+++ b/src/Components/__stories__/CollectionsHubsNav.story.tsx
@@ -1,29 +1,37 @@
 import { Theme } from "@artsy/palette"
-import { MockRelayRenderer } from "DevTools"
+import { CollectionsHubsNavQuery } from "__generated__/CollectionsHubsNavQuery.graphql"
+import { SystemContextConsumer } from "Artsy"
+import { renderWithLoadProgress } from "Artsy/Relay/renderWithLoadProgress"
 import React from "react"
-import { graphql } from "react-relay"
+import { graphql, QueryRenderer } from "react-relay"
 import { storiesOf } from "storybook/storiesOf"
-import { marketingHubCollections } from "../_fixtures_/collectionsHubs"
 import { CollectionsHubsNavFragmentContainer } from "../CollectionsHubsNav"
 
 storiesOf("Components/CollectionsHubsNav", module).add("default", () => (
-  <Theme>{render()}</Theme>
+  <Theme>
+    <CollectionsHubsNavQueryRenderer />
+  </Theme>
 ))
 
-const hubsQuery = graphql`
-  query CollectionsHubsNavStoryQuery {
-    marketingHubCollections {
-      ...CollectionsHubsNav_marketingHubCollections
-    }
-  }
-`
-
-const render = () => {
+const CollectionsHubsNavQueryRenderer = () => {
   return (
-    <MockRelayRenderer
-      Component={CollectionsHubsNavFragmentContainer}
-      mockData={{ marketingHubCollections }}
-      query={hubsQuery}
-    />
+    <SystemContextConsumer>
+      {({ relayEnvironment }) => {
+        return (
+          <QueryRenderer<CollectionsHubsNavQuery>
+            environment={relayEnvironment}
+            variables={{}}
+            query={graphql`
+              query CollectionsHubsNavQuery {
+                marketingCollections(size: 6) {
+                  ...CollectionsHubsNav_marketingCollections
+                }
+              }
+            `}
+            render={renderWithLoadProgress(CollectionsHubsNavFragmentContainer)}
+          />
+        )
+      }}
+    </SystemContextConsumer>
   )
 }

--- a/src/Components/__stories__/CollectionsHubsNav.story.tsx
+++ b/src/Components/__stories__/CollectionsHubsNav.story.tsx
@@ -1,10 +1,11 @@
 import { Theme } from "@artsy/palette"
+import { CollectionsHubsNav_marketingHubCollections } from "__generated__/CollectionsHubsNav_marketingHubCollections.graphql"
 import { MockRelayRenderer } from "DevTools"
 import React from "react"
 import { graphql } from "react-relay"
 import { storiesOf } from "storybook/storiesOf"
+import { marketingHubCollections } from "../_fixtures_/collectionsHubs"
 import { CollectionsHubsNavFragmentContainer } from "../CollectionsHubsNav"
-import { imageSamples } from "./ImageLink.story"
 
 storiesOf("Components/CollectionsHubsNav", module).add("default", () => (
   <Theme>{render()}</Theme>
@@ -17,39 +18,6 @@ const hubsQuery = graphql`
     }
   }
 `
-
-const marketingHubCollections = [
-  {
-    slug: "street-art  ",
-    title: "Street Art  ",
-    thumbnail: imageSamples.streetArt,
-  },
-  {
-    slug: "pre-twentieth-century",
-    title: "Pre-20th",
-    thumbnail: imageSamples.preTwentiethCentury,
-  },
-  {
-    slug: "post-war-art",
-    title: "Post-War",
-    thumbnail: imageSamples.postWarArt,
-  },
-  {
-    slug: "contemporary-art",
-    title: "Contemporary",
-    thumbnail: imageSamples.contemporaryArt,
-  },
-  {
-    slug: "impressionist-and-modern-art",
-    title: "Impressionist & Modern",
-    thumbnail: imageSamples.impressionistAndModernArt,
-  },
-  {
-    slug: "photography",
-    title: "Photography",
-    thumbnail: imageSamples.photography,
-  },
-]
 
 const render = () => {
   return (

--- a/src/Components/__stories__/ImageLink.story.tsx
+++ b/src/Components/__stories__/ImageLink.story.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { storiesOf } from "storybook/storiesOf"
+import { imageSamples } from "../_fixtures_/collectionsHubs"
 import { ImageLink } from "../ImageLink"
 
 storiesOf("Components/ImageLink", module)
@@ -38,18 +39,3 @@ storiesOf("Components/ImageLink", module)
       Impressionist and Modern Art
     </ImageLink>
   ))
-
-export const imageSamples = {
-  contemporaryArt:
-    "https://d32dm0rphc51dk.cloudfront.net/f_WVnADS9HIc5dQ-sIcejA/thumb.jpg",
-  postWarArt:
-    "https://d32dm0rphc51dk.cloudfront.net/dtSncXEq-KNTWbWNG_xMTA/thumb.jpg",
-  impressionistAndModernArt:
-    "https://d32dm0rphc51dk.cloudfront.net/Y2fVKtk64zRDfoGWgYSkJA/thumb.jpg",
-  preTwentiethCentury:
-    "https://d32dm0rphc51dk.cloudfront.net/adz_7LkzkU5A_ucVjQLMtQ/thumb.jpg",
-  photography:
-    "https://d32dm0rphc51dk.cloudfront.net/Cy1tDMUKkF_H-QN4BIDlDA/thumb.jpg",
-  streetArt:
-    "https://d32dm0rphc51dk.cloudfront.net/Tk7srLDTS-0Y60mbN7gWew/thumb.jpg",
-}

--- a/src/Components/_fixtures_/collectionsHubs.tsx
+++ b/src/Components/_fixtures_/collectionsHubs.tsx
@@ -1,0 +1,61 @@
+import { CollectionsHubsNav_marketingHubCollections } from "__generated__/CollectionsHubsNav_marketingHubCollections.graphql"
+
+export const imageSamples = {
+  contemporaryArt:
+    "https://d32dm0rphc51dk.cloudfront.net/f_WVnADS9HIc5dQ-sIcejA/thumb.jpg",
+  postWarArt:
+    "https://d32dm0rphc51dk.cloudfront.net/dtSncXEq-KNTWbWNG_xMTA/thumb.jpg",
+  impressionistAndModernArt:
+    "https://d32dm0rphc51dk.cloudfront.net/Y2fVKtk64zRDfoGWgYSkJA/thumb.jpg",
+  preTwentiethCentury:
+    "https://d32dm0rphc51dk.cloudfront.net/adz_7LkzkU5A_ucVjQLMtQ/thumb.jpg",
+  photography:
+    "https://d32dm0rphc51dk.cloudfront.net/Cy1tDMUKkF_H-QN4BIDlDA/thumb.jpg",
+  streetArt:
+    "https://d32dm0rphc51dk.cloudfront.net/Tk7srLDTS-0Y60mbN7gWew/thumb.jpg",
+}
+
+export const marketingHubCollections: CollectionsHubsNav_marketingHubCollections = [
+  {
+    id: "1",
+    slug: "street-art  ",
+    title: "Street Art  ",
+    thumbnail: imageSamples.streetArt,
+    " $refType": null,
+  },
+  {
+    id: "2",
+    slug: "pre-twentieth-century",
+    title: "Pre-20th",
+    thumbnail: imageSamples.preTwentiethCentury,
+    " $refType": null,
+  },
+  {
+    id: "3",
+    slug: "post-war-art",
+    title: "Post-War",
+    thumbnail: imageSamples.postWarArt,
+    " $refType": null,
+  },
+  {
+    id: "4",
+    slug: "contemporary-art",
+    title: "Contemporary",
+    thumbnail: imageSamples.contemporaryArt,
+    " $refType": null,
+  },
+  {
+    id: "5",
+    slug: "impressionist-and-modern-art",
+    title: "Impressionist & Modern",
+    thumbnail: imageSamples.impressionistAndModernArt,
+    " $refType": null,
+  },
+  {
+    id: "6",
+    slug: "photography",
+    title: "Photography",
+    thumbnail: imageSamples.photography,
+    " $refType": null,
+  },
+]

--- a/src/Components/_fixtures_/collectionsHubs.tsx
+++ b/src/Components/_fixtures_/collectionsHubs.tsx
@@ -1,4 +1,4 @@
-import { CollectionsHubsNav_marketingHubCollections } from "__generated__/CollectionsHubsNav_marketingHubCollections.graphql"
+import { CollectionsHubsNav_marketingCollections } from "__generated__/CollectionsHubsNav_marketingCollections.graphql"
 
 export const imageSamples = {
   contemporaryArt:
@@ -15,7 +15,7 @@ export const imageSamples = {
     "https://d32dm0rphc51dk.cloudfront.net/Tk7srLDTS-0Y60mbN7gWew/thumb.jpg",
 }
 
-export const marketingHubCollections: CollectionsHubsNav_marketingHubCollections = [
+export const marketingHubCollections: CollectionsHubsNav_marketingCollections = [
   {
     id: "1",
     slug: "street-art  ",

--- a/src/__generated__/CollectionsHubsNavQuery.graphql.ts
+++ b/src/__generated__/CollectionsHubsNavQuery.graphql.ts
@@ -1,29 +1,29 @@
 /* tslint:disable */
 
 import { ConcreteRequest } from "relay-runtime";
-import { CollectionsHubsNav_marketingHubCollections$ref } from "./CollectionsHubsNav_marketingHubCollections.graphql";
-export type CollectionsHubsNavStoryQueryVariables = {};
-export type CollectionsHubsNavStoryQueryResponse = {
-    readonly marketingHubCollections: ReadonlyArray<{
-        readonly " $fragmentRefs": CollectionsHubsNav_marketingHubCollections$ref;
+import { CollectionsHubsNav_marketingCollections$ref } from "./CollectionsHubsNav_marketingCollections.graphql";
+export type CollectionsHubsNavQueryVariables = {};
+export type CollectionsHubsNavQueryResponse = {
+    readonly marketingCollections: ReadonlyArray<{
+        readonly " $fragmentRefs": CollectionsHubsNav_marketingCollections$ref;
     }>;
 };
-export type CollectionsHubsNavStoryQuery = {
-    readonly response: CollectionsHubsNavStoryQueryResponse;
-    readonly variables: CollectionsHubsNavStoryQueryVariables;
+export type CollectionsHubsNavQuery = {
+    readonly response: CollectionsHubsNavQueryResponse;
+    readonly variables: CollectionsHubsNavQueryVariables;
 };
 
 
 
 /*
-query CollectionsHubsNavStoryQuery {
-  marketingHubCollections {
-    ...CollectionsHubsNav_marketingHubCollections
+query CollectionsHubsNavQuery {
+  marketingCollections(size: 6) {
+    ...CollectionsHubsNav_marketingCollections
     __id: id
   }
 }
 
-fragment CollectionsHubsNav_marketingHubCollections on MarketingCollection {
+fragment CollectionsHubsNav_marketingCollections on MarketingCollection {
   id
   slug
   title
@@ -33,7 +33,15 @@ fragment CollectionsHubsNav_marketingHubCollections on MarketingCollection {
 */
 
 const node: ConcreteRequest = (function(){
-var v0 = {
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "size",
+    "value": 6,
+    "type": "Int"
+  }
+],
+v1 = {
   "kind": "ScalarField",
   "alias": "__id",
   "name": "id",
@@ -43,13 +51,13 @@ var v0 = {
 return {
   "kind": "Request",
   "operationKind": "query",
-  "name": "CollectionsHubsNavStoryQuery",
+  "name": "CollectionsHubsNavQuery",
   "id": null,
-  "text": "query CollectionsHubsNavStoryQuery {\n  marketingHubCollections {\n    ...CollectionsHubsNav_marketingHubCollections\n    __id: id\n  }\n}\n\nfragment CollectionsHubsNav_marketingHubCollections on MarketingCollection {\n  id\n  slug\n  title\n  thumbnail\n  __id: id\n}\n",
+  "text": "query CollectionsHubsNavQuery {\n  marketingCollections(size: 6) {\n    ...CollectionsHubsNav_marketingCollections\n    __id: id\n  }\n}\n\nfragment CollectionsHubsNav_marketingCollections on MarketingCollection {\n  id\n  slug\n  title\n  thumbnail\n  __id: id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
-    "name": "CollectionsHubsNavStoryQuery",
+    "name": "CollectionsHubsNavQuery",
     "type": "Query",
     "metadata": null,
     "argumentDefinitions": [],
@@ -57,33 +65,33 @@ return {
       {
         "kind": "LinkedField",
         "alias": null,
-        "name": "marketingHubCollections",
-        "storageKey": null,
-        "args": null,
+        "name": "marketingCollections",
+        "storageKey": "marketingCollections(size:6)",
+        "args": v0,
         "concreteType": "MarketingCollection",
         "plural": true,
         "selections": [
           {
             "kind": "FragmentSpread",
-            "name": "CollectionsHubsNav_marketingHubCollections",
+            "name": "CollectionsHubsNav_marketingCollections",
             "args": null
           },
-          v0
+          v1
         ]
       }
     ]
   },
   "operation": {
     "kind": "Operation",
-    "name": "CollectionsHubsNavStoryQuery",
+    "name": "CollectionsHubsNavQuery",
     "argumentDefinitions": [],
     "selections": [
       {
         "kind": "LinkedField",
         "alias": null,
-        "name": "marketingHubCollections",
-        "storageKey": null,
-        "args": null,
+        "name": "marketingCollections",
+        "storageKey": "marketingCollections(size:6)",
+        "args": v0,
         "concreteType": "MarketingCollection",
         "plural": true,
         "selections": [
@@ -115,12 +123,12 @@ return {
             "args": null,
             "storageKey": null
           },
-          v0
+          v1
         ]
       }
     ]
   }
 };
 })();
-(node as any).hash = 'd804699e56600f4d31692b93a706bfab';
+(node as any).hash = 'ca5e20922d40db7c07fa18726837321a';
 export default node;

--- a/src/__generated__/CollectionsHubsNav_marketingCollections.graphql.ts
+++ b/src/__generated__/CollectionsHubsNav_marketingCollections.graphql.ts
@@ -1,21 +1,21 @@
 /* tslint:disable */
 
 import { ConcreteFragment } from "relay-runtime";
-declare const _CollectionsHubsNav_marketingHubCollections$ref: unique symbol;
-export type CollectionsHubsNav_marketingHubCollections$ref = typeof _CollectionsHubsNav_marketingHubCollections$ref;
-export type CollectionsHubsNav_marketingHubCollections = ReadonlyArray<{
+declare const _CollectionsHubsNav_marketingCollections$ref: unique symbol;
+export type CollectionsHubsNav_marketingCollections$ref = typeof _CollectionsHubsNav_marketingCollections$ref;
+export type CollectionsHubsNav_marketingCollections = ReadonlyArray<{
     readonly id: string;
     readonly slug: string;
     readonly title: string;
     readonly thumbnail: string | null;
-    readonly " $refType": CollectionsHubsNav_marketingHubCollections$ref;
+    readonly " $refType": CollectionsHubsNav_marketingCollections$ref;
 }>;
 
 
 
 const node: ConcreteFragment = {
   "kind": "Fragment",
-  "name": "CollectionsHubsNav_marketingHubCollections",
+  "name": "CollectionsHubsNav_marketingCollections",
   "type": "MarketingCollection",
   "metadata": {
     "plural": true
@@ -59,5 +59,5 @@ const node: ConcreteFragment = {
     }
   ]
 };
-(node as any).hash = '459c406a45d0cbce01052c982a5228ff';
+(node as any).hash = 'c4db8e5bdbdcd65e72b86c886378350b';
 export default node;

--- a/src/__generated__/routes_CollectAppQuery.graphql.ts
+++ b/src/__generated__/routes_CollectAppQuery.graphql.ts
@@ -2,6 +2,7 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { CollectApp_viewer$ref } from "./CollectApp_viewer.graphql";
+import { CollectionsHubsNav_marketingCollections$ref } from "./CollectionsHubsNav_marketingCollections.graphql";
 export type routes_CollectAppQueryVariables = {
     readonly medium?: string | null;
     readonly major_periods?: ReadonlyArray<string | null> | null;
@@ -25,6 +26,9 @@ export type routes_CollectAppQueryResponse = {
     readonly viewer: ({
         readonly " $fragmentRefs": CollectApp_viewer$ref;
     }) | null;
+    readonly marketingCollections: ReadonlyArray<{
+        readonly " $fragmentRefs": CollectionsHubsNav_marketingCollections$ref;
+    }>;
 };
 export type routes_CollectAppQuery = {
     readonly response: routes_CollectAppQueryResponse;
@@ -56,6 +60,10 @@ query routes_CollectAppQuery(
   viewer {
     ...CollectApp_viewer_3XOIsA
   }
+  marketingCollections(size: 6) {
+    ...CollectionsHubsNav_marketingCollections
+    __id: id
+  }
 }
 
 fragment CollectApp_viewer_3XOIsA on Viewer {
@@ -64,6 +72,14 @@ fragment CollectApp_viewer_3XOIsA on Viewer {
     __id
   }
   ...CollectFilterContainer_viewer_3XOIsA
+}
+
+fragment CollectionsHubsNav_marketingCollections on MarketingCollection {
+  id
+  slug
+  title
+  thumbnail
+  __id: id
 }
 
 fragment SeoProductsForArtworks_artworks on FilterArtworks {
@@ -416,13 +432,28 @@ var v0 = [
     "defaultValue": null
   }
 ],
-v1 = {
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "size",
+    "value": 6,
+    "type": "Int"
+  }
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": "__id",
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
   "kind": "Literal",
   "name": "size",
   "value": 0,
   "type": "Int"
 },
-v2 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "after",
@@ -436,56 +467,49 @@ v2 = [
     "type": "Int"
   }
 ],
-v3 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__id",
   "args": null,
   "storageKey": null
 },
-v4 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "date",
   "args": null,
   "storageKey": null
 },
-v5 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v6 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "is_acquireable",
   "args": null,
   "storageKey": null
 },
-v7 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "title",
   "args": null,
   "storageKey": null
 },
-v8 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v9 = {
-  "kind": "ScalarField",
-  "alias": "__id",
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v10 = [
+v11 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -500,9 +524,9 @@ v10 = [
     ],
     "storageKey": "url(version:\"larger\")"
   },
-  v9
+  v2
 ],
-v11 = [
+v12 = [
   {
     "kind": "Literal",
     "name": "shallow",
@@ -510,37 +534,37 @@ v11 = [
     "type": "Boolean"
   }
 ],
-v12 = {
+v13 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "type",
   "args": null,
   "storageKey": null
 },
-v13 = {
+v14 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v14 = {
+v15 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "cursor",
   "args": null,
   "storageKey": null
 },
-v15 = {
+v16 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "page",
   "args": null,
   "storageKey": null
 },
-v16 = [
-  v14,
+v17 = [
   v15,
+  v16,
   {
     "kind": "ScalarField",
     "alias": null,
@@ -549,7 +573,7 @@ v16 = [
     "storageKey": null
   }
 ],
-v17 = {
+v18 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "display",
@@ -561,7 +585,7 @@ return {
   "operationKind": "query",
   "name": "routes_CollectAppQuery",
   "id": null,
-  "text": "query routes_CollectAppQuery(\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $for_sale: Boolean\n  $sort: String\n  $at_auction: Boolean\n  $acquireable: Boolean\n  $offerable: Boolean\n  $inquireable_only: Boolean\n  $price_range: String\n  $height: String\n  $width: String\n  $dimension_range: String\n  $artist_id: String\n  $attribution_class: [String]\n  $color: String\n  $page: Int\n) {\n  viewer {\n    ...CollectApp_viewer_3XOIsA\n  }\n}\n\nfragment CollectApp_viewer_3XOIsA on Viewer {\n  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {\n    ...SeoProductsForArtworks_artworks\n    __id\n  }\n  ...CollectFilterContainer_viewer_3XOIsA\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n          __id: id\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n              __id: id\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment CollectFilterContainer_viewer_3XOIsA on Viewer {\n  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        id\n        __id\n      }\n    }\n    __id\n  }\n  ...CollectRefetch_viewer_3XOIsA\n}\n\nfragment CollectRefetch_viewer_3XOIsA on Viewer {\n  filtered_artworks: filter_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, offerable: $offerable, inquireable_only: $inquireable_only, size: 0, sort: $sort, price_range: $price_range, height: $height, width: $width, artist_id: $artist_id, attribution_class: $attribution_class, color: $color, page: $page, dimension_range: $dimension_range) {\n    ...CollectArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment CollectArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n        __id: id\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n    __id: id\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
+  "text": "query routes_CollectAppQuery(\n  $medium: String\n  $major_periods: [String]\n  $partner_id: ID\n  $for_sale: Boolean\n  $sort: String\n  $at_auction: Boolean\n  $acquireable: Boolean\n  $offerable: Boolean\n  $inquireable_only: Boolean\n  $price_range: String\n  $height: String\n  $width: String\n  $dimension_range: String\n  $artist_id: String\n  $attribution_class: [String]\n  $color: String\n  $page: Int\n) {\n  viewer {\n    ...CollectApp_viewer_3XOIsA\n  }\n  marketingCollections(size: 6) {\n    ...CollectionsHubsNav_marketingCollections\n    __id: id\n  }\n}\n\nfragment CollectApp_viewer_3XOIsA on Viewer {\n  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {\n    ...SeoProductsForArtworks_artworks\n    __id\n  }\n  ...CollectFilterContainer_viewer_3XOIsA\n}\n\nfragment CollectionsHubsNav_marketingCollections on MarketingCollection {\n  id\n  slug\n  title\n  thumbnail\n  __id: id\n}\n\nfragment SeoProductsForArtworks_artworks on FilterArtworks {\n  artworks_connection(first: 30, after: \"\") {\n    edges {\n      node {\n        __id\n        availability\n        category\n        date\n        href\n        is_acquireable\n        is_price_range\n        price\n        price_currency\n        title\n        artists {\n          name\n          __id\n        }\n        image {\n          url(version: \"larger\")\n          __id: id\n        }\n        meta {\n          description\n        }\n        partner(shallow: true) {\n          name\n          type\n          profile {\n            icon {\n              url(version: \"larger\")\n              __id: id\n            }\n            __id\n          }\n          locations(size: 1) {\n            address\n            address_2\n            city\n            state\n            country\n            postal_code\n            phone\n            __id\n          }\n          __id\n        }\n      }\n    }\n  }\n  __id\n}\n\nfragment CollectFilterContainer_viewer_3XOIsA on Viewer {\n  filter_artworks(aggregations: [MEDIUM, TOTAL], size: 0) {\n    aggregations {\n      slice\n      counts {\n        name\n        id\n        __id\n      }\n    }\n    __id\n  }\n  ...CollectRefetch_viewer_3XOIsA\n}\n\nfragment CollectRefetch_viewer_3XOIsA on Viewer {\n  filtered_artworks: filter_artworks(aggregations: [TOTAL], medium: $medium, major_periods: $major_periods, partner_id: $partner_id, for_sale: $for_sale, at_auction: $at_auction, acquireable: $acquireable, offerable: $offerable, inquireable_only: $inquireable_only, size: 0, sort: $sort, price_range: $price_range, height: $height, width: $width, artist_id: $artist_id, attribution_class: $attribution_class, color: $color, page: $page, dimension_range: $dimension_range) {\n    ...CollectArtworkGrid_filtered_artworks\n    __id\n  }\n}\n\nfragment CollectArtworkGrid_filtered_artworks on FilterArtworks {\n  __id\n  artworks: artworks_connection(first: 30, after: \"\") {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    ...ArtworkGrid_artworks\n    edges {\n      node {\n        __id\n      }\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnection {\n  edges {\n    node {\n      __id\n      id\n      href\n      image {\n        aspect_ratio\n        __id: id\n      }\n      ...GridItem_artwork\n    }\n  }\n}\n\nfragment GridItem_artwork on Artwork {\n  _id\n  title\n  image_title\n  image {\n    placeholder\n    url(version: \"large\")\n    aspect_ratio\n    __id: id\n  }\n  href\n  ...Metadata_artwork\n  ...Save_artwork\n  ...Badge_artwork\n  __id\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  ...Contact_artwork\n  href\n  __id\n}\n\nfragment Save_artwork on Artwork {\n  __id\n  _id\n  id\n  is_saved\n  title\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable\n  is_acquireable\n  is_offerable\n  href\n  sale {\n    is_preview\n    display_timely_at\n    __id\n  }\n  __id\n}\n\nfragment Details_artwork on Artwork {\n  href\n  title\n  date\n  sale_message\n  cultural_maker\n  artists(shallow: true) {\n    __id\n    href\n    name\n  }\n  collecting_institution\n  partner(shallow: true) {\n    name\n    href\n    __id\n  }\n  sale {\n    is_auction\n    is_closed\n    __id\n  }\n  sale_artwork {\n    counts {\n      bidder_positions\n    }\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    __id\n  }\n  __id\n}\n\nfragment Contact_artwork on Artwork {\n  href\n  is_inquireable\n  sale {\n    is_auction\n    is_live_open\n    is_open\n    is_closed\n    __id\n  }\n  partner(shallow: true) {\n    type\n    __id\n  }\n  sale_artwork {\n    highest_bid {\n      display\n      __id: id\n    }\n    opening_bid {\n      display\n    }\n    counts {\n      bidder_positions\n    }\n    __id\n  }\n  __id\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -688,6 +712,23 @@ return {
             ]
           }
         ]
+      },
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "marketingCollections",
+        "storageKey": "marketingCollections(size:6)",
+        "args": v1,
+        "concreteType": "MarketingCollection",
+        "plural": true,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "CollectionsHubsNav_marketingCollections",
+            "args": null
+          },
+          v2
+        ]
       }
     ]
   },
@@ -720,7 +761,7 @@ return {
                 ],
                 "type": "[ArtworkAggregation]"
               },
-              v1
+              v3
             ],
             "concreteType": "FilterArtworks",
             "plural": false,
@@ -730,7 +771,7 @@ return {
                 "alias": null,
                 "name": "artworks_connection",
                 "storageKey": "artworks_connection(after:\"\",first:30)",
-                "args": v2,
+                "args": v4,
                 "concreteType": "ArtworkConnection",
                 "plural": false,
                 "selections": [
@@ -759,7 +800,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v3,
+                          v5,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -767,9 +808,9 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v4,
-                          v5,
                           v6,
+                          v7,
+                          v8,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -791,7 +832,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v7,
+                          v9,
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -801,8 +842,8 @@ return {
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
-                              v8,
-                              v3
+                              v10,
+                              v5
                             ]
                           },
                           {
@@ -813,7 +854,7 @@ return {
                             "args": null,
                             "concreteType": "Image",
                             "plural": false,
-                            "selections": v10
+                            "selections": v11
                           },
                           {
                             "kind": "LinkedField",
@@ -838,12 +879,12 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": v11,
+                            "args": v12,
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              v8,
-                              v12,
+                              v10,
+                              v13,
                               {
                                 "kind": "LinkedField",
                                 "alias": null,
@@ -861,9 +902,9 @@ return {
                                     "args": null,
                                     "concreteType": "Image",
                                     "plural": false,
-                                    "selections": v10
+                                    "selections": v11
                                   },
-                                  v3
+                                  v5
                                 ]
                               },
                               {
@@ -931,10 +972,10 @@ return {
                                     "args": null,
                                     "storageKey": null
                                   },
-                                  v3
+                                  v5
                                 ]
                               },
-                              v3
+                              v5
                             ]
                           }
                         ]
@@ -943,7 +984,7 @@ return {
                   }
                 ]
               },
-              v3,
+              v5,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -969,9 +1010,9 @@ return {
                     "concreteType": "AggregationCount",
                     "plural": true,
                     "selections": [
-                      v8,
-                      v13,
-                      v3
+                      v10,
+                      v14,
+                      v5
                     ]
                   }
                 ]
@@ -1082,7 +1123,7 @@ return {
                 "variableName": "price_range",
                 "type": "String"
               },
-              v1,
+              v3,
               {
                 "kind": "Variable",
                 "name": "sort",
@@ -1099,13 +1140,13 @@ return {
             "concreteType": "FilterArtworks",
             "plural": false,
             "selections": [
-              v3,
+              v5,
               {
                 "kind": "LinkedField",
                 "alias": "artworks",
                 "name": "artworks_connection",
                 "storageKey": "artworks_connection(after:\"\",first:30)",
-                "args": v2,
+                "args": v4,
                 "concreteType": "ArtworkConnection",
                 "plural": false,
                 "selections": [
@@ -1151,7 +1192,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": true,
-                        "selections": v16
+                        "selections": v17
                       },
                       {
                         "kind": "LinkedField",
@@ -1161,7 +1202,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": false,
-                        "selections": v16
+                        "selections": v17
                       },
                       {
                         "kind": "LinkedField",
@@ -1171,7 +1212,7 @@ return {
                         "args": null,
                         "concreteType": "PageCursor",
                         "plural": false,
-                        "selections": v16
+                        "selections": v17
                       },
                       {
                         "kind": "LinkedField",
@@ -1182,8 +1223,8 @@ return {
                         "concreteType": "PageCursor",
                         "plural": false,
                         "selections": [
-                          v14,
-                          v15
+                          v15,
+                          v16
                         ]
                       }
                     ]
@@ -1211,17 +1252,17 @@ return {
                             "alias": null,
                             "name": "artists",
                             "storageKey": "artists(shallow:true)",
-                            "args": v11,
+                            "args": v12,
                             "concreteType": "Artist",
                             "plural": true,
                             "selections": [
-                              v3,
                               v5,
-                              v8
+                              v7,
+                              v10
                             ]
                           },
-                          v3,
                           v5,
+                          v7,
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -1238,7 +1279,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              v9,
+                              v2,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -1269,7 +1310,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v7,
+                          v9,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1277,7 +1318,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v4,
+                          v6,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1292,7 +1333,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v13,
+                          v14,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1305,14 +1346,14 @@ return {
                             "alias": null,
                             "name": "partner",
                             "storageKey": "partner(shallow:true)",
-                            "args": v11,
+                            "args": v12,
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              v8,
+                              v10,
+                              v7,
                               v5,
-                              v3,
-                              v12
+                              v13
                             ]
                           },
                           {
@@ -1338,7 +1379,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              v3,
+                              v5,
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -1405,8 +1446,8 @@ return {
                                 "concreteType": "SaleArtworkHighestBid",
                                 "plural": false,
                                 "selections": [
-                                  v17,
-                                  v9
+                                  v18,
+                                  v2
                                 ]
                               },
                               {
@@ -1418,10 +1459,10 @@ return {
                                 "concreteType": "SaleArtworkOpeningBid",
                                 "plural": false,
                                 "selections": [
-                                  v17
+                                  v18
                                 ]
                               },
-                              v3
+                              v5
                             ]
                           },
                           {
@@ -1445,7 +1486,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          v6,
+                          v8,
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1471,10 +1512,38 @@ return {
         "handle": "viewer",
         "key": "",
         "filters": null
+      },
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "marketingCollections",
+        "storageKey": "marketingCollections(size:6)",
+        "args": v1,
+        "concreteType": "MarketingCollection",
+        "plural": true,
+        "selections": [
+          v14,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "slug",
+            "args": null,
+            "storageKey": null
+          },
+          v9,
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "thumbnail",
+            "args": null,
+            "storageKey": null
+          },
+          v2
+        ]
       }
     ]
   }
 };
 })();
-(node as any).hash = 'a1652f1e879b17af559ab41c26c672f9';
+(node as any).hash = 'a466090da532a4800cce385467b41219';
 export default node;


### PR DESCRIPTION
This continues our work from earlier this week on adding the collection hubs to the collect page.

The collections hubs nav is now using real data, but pulling from `marketingCollections` instead of `marketingHubCollections`. Once we get the data into staging, we can switch this back to use `marketingHubCollections`. 

Things yet to do:

- [x] Get type-check passing. It's currently failing on a mismatch of types for `CollectionsHubsNav_marketingCollections`. This is a similar problem to one I saw @damassi run into today. He suggested there should be a way to fix it by elevating types up the chain, but I didn't totally understand. Maybe we can work with him to figure out what we need to do.
- [x] Put behind a feature flag
- [ ] Update the UI according to Jeffrey's specs. This means using a constant 20px gutter and having the images auto-scale to take up as much space as would fill the row, with a matching height. A codesandbox POC is here -  https://codepen.io/pepopowitz/pen/GVOzee
- [x] Verify tests still pass! There might be some fixtures that need data added to them.